### PR TITLE
Clarified passive abilities when jailed

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -95,7 +95,7 @@
       "goal":"Lynch every criminal and evildoer.",
       "classicResults":"Survivor, Vampire Hunter, Amnesiac",
       "covenResults":"Survivor, Vampire Hunter, Amnesiac, Medusa, Psychic",
-      "additional":"Unlike the original video game, the Vampire Hunter will not be able to listen into Vampire meetings. This is due VRChat limitations.\n\nIf your target is converted the same Night you check them, you will not prevent the conversion nor will you stake them.\n\nIf a Vampire Hunter is jailed or roleblocked, they will still stake any Vampires visiting them.",
+      "additional":"Due to VRChat limitations, unlike the original video game, the Vampire Hunter will not be able to listen into Vampire meetings.\n\nIf your target is converted the same Night you check them, you will not prevent the conversion nor will you stake them.\n\nIf a Vampire Hunter is jailed or roleblocked, they will still stake any Vampires visiting them.",
       "dlc":false,
       "unique":false,
       "community":false,

--- a/roles.json
+++ b/roles.json
@@ -95,7 +95,7 @@
       "goal":"Lynch every criminal and evildoer.",
       "classicResults":"Survivor, Vampire Hunter, Amnesiac",
       "covenResults":"Survivor, Vampire Hunter, Amnesiac, Medusa, Psychic",
-      "additional":"Unlike the original video game, the Vampire Hunter will not be able to listen into Vampire meetings.\n\nIf your target is converted the same Night you check them, you will not prevent the conversion nor will you stake them.\n\nIf a Vampire Hunter is roleblocked, they will still stake any Vampires visiting them.",
+      "additional":"Unlike the original video game, the Vampire Hunter will not be able to listen into Vampire meetings. This is due VRChat limitations.\n\nIf your target is converted the same Night you check them, you will not prevent the conversion nor will you stake them.\n\nIf a Vampire Hunter is jailed or roleblocked, they will still stake any Vampires visiting them.",
       "dlc":false,
       "unique":false,
       "community":false,

--- a/roles.json
+++ b/roles.json
@@ -720,7 +720,7 @@
       "attack":"Unstoppable",
       "defense":"Basic",
       "abilities":"Choose to Douse a player in gasoline each night.\n\nOr Ignite all Doused targets, dealing an Unstoppable Attack to all of them.",
-      "attributes":"You will passively douse anyone that visits you and learn their house numbers.\n\nIf you happen to become Doused, you can choose to do no action at Night to clean the gasoline off yourself. Ignites will kill you if you are doused.\n\nDoused players will show as Arsonist results to Investigator and Consigliere.",
+      "attributes":"You will passively douse anyone that visits you and learn their house numbers. This happens even if you are jailed or roleblocked.\n\nIf you happen to become Doused, you can choose to do no action at Night to clean the gasoline off yourself. Ignites will kill you if you are doused.\n\nDoused players will show as Arsonist results to Investigator and Consigliere.",
       "goal":"Live to see everyone burn.",
       "classicResults":"Bodyguard, Godfather, Arsonist",
       "covenResults":"Bodyguard, Godfather, Arsonist, Crusader",


### PR DESCRIPTION
[Equiliez](https://vrchat.com/home/user/usr_20fe2894-7ae9-4418-8783-e79221978fe3) pointed out some mistakes in my understanding of passive abilities and jailing. The ToS wiki clearly has notes saying that both the Arsonist and Vampire Hunter passive abilities work while they are jailed. I don't see how it makes sense, but unless we go actually test it in the game, we have to follow the wiki.

### Arsonist
- Added note to attributes:
> You will passively douse anyone that visits you and learn their house numbers. **This happens even if you are jailed or roleblocked.**

### Vampire Hunter
- Slight change to additional note:
> If a Vampire Hunter is **jailed or** roleblocked, they will still stake any Vampires visiting them.
- Added a clarification to additional note:
> **Due to VRChat limitations,** unlike the original video game, the Vampire Hunter will not be able to listen into Vampire meetings.